### PR TITLE
add assertion that create_table() has return value

### DIFF
--- a/app/testing/dog_test.py
+++ b/app/testing/dog_test.py
@@ -33,6 +33,7 @@ class TestDog:
         Session = sessionmaker(engine)
         session = Session()
         assert(session.query(Dog))
+        assert engine is not None, "Make sure the create_table function returns the engine"
 
     def test_saves_dog(self):
         '''contains function "save()" that takes a Dog instance and session as arguments, saves the dog to the database, and returns the session.'''


### PR DESCRIPTION
When I was first working on this lab, this test seemed to pass before I did anything within `create_table`, it continued to pass after I added `base.metadata.create_all(engine)`, but subsequent tests were failing because they expected the engine to be returned from `create_table`